### PR TITLE
Adding instrument activation confidence annotations

### DIFF
--- a/medleydb/__init__.py
+++ b/medleydb/__init__.py
@@ -23,6 +23,7 @@ INST_TAXONOMY = path.join(path.dirname(__file__), 'taxonomy.yaml')
 AUDIO_DIR = path.join(MEDLEYDB_PATH, 'Audio')
 ANNOTATION_DIR = path.join(MEDLEYDB_PATH, 'Annotations')
 MELODY_DIR = path.join(ANNOTATION_DIR, 'Melody_Annotations')
+ACTIVATIONS_DIR = path.join(ANNOTATION_DIR, 'Instrument_Activations')
 PITCH_DIR = path.join(ANNOTATION_DIR, 'Pitch_Annotations')
 RANKINGS_DIR = path.join(ANNOTATION_DIR, 'Stem_Rankings')
 

--- a/medleydb/multitrack.py
+++ b/medleydb/multitrack.py
@@ -9,6 +9,7 @@ import csv
 from . import INST_TAXONOMY
 from . import PITCH_DIR
 from . import MELODY_DIR
+from . import ACTIVATIONS_DIR
 from . import RANKINGS_DIR
 
 _YESNO = dict(yes=True, no=False)
@@ -26,6 +27,8 @@ _MELODY1_FMT = "%s_MELODY1.csv"
 _MELODY2_FMT = "%s_MELODY2.csv"
 _MELODY3_FMT = "%s_MELODY3.csv"
 _RANKING_FMT = "%s_RANKING.txt"
+_ACTIVATION_CONFS_DIR = 'ACTIVATION_CONF'
+_ACTIVATION_CONFS_FMT = "%s_ACTIVATION_CONF.lab"
 _PITCH_FMT = "%s.csv"
 
 
@@ -55,6 +58,7 @@ class MultiTrack(object):
         raw_audio (list of Track objects): List of raw audio tracks.
         raw_instruments (list of strings): List of raw track instrument labels.
         stem_instruments (list of strings): List of stem instrument labels.
+        stem_activations (list): List of stem activation confidence annotations
         stems (list of Track objects): List of stems.
         title (str): Track title.
         track_id (str): Unique track id in the form "ArtistName_TrackTitle".
@@ -117,6 +121,7 @@ class MultiTrack(object):
             self.melody3_annotation
         ) = self._get_melody_annotations()
         self.predominant_stem = self._get_predominant_stem()
+        self.stem_activations = self._get_activation_annotations()
 
     def _load_metadata(self):
         """Load the metadata file.
@@ -173,6 +178,15 @@ class MultiTrack(object):
             read_annotation_file(melody2_fpath),
             read_annotation_file(melody3_fpath)
         )
+
+    def _get_activation_annotations(self):
+        """Get activation confidence annotation if file exists.
+        """
+        fname = _ACTIVATION_CONFS_FMT % self.track_id
+        activation_annotation_fpath = os.path.join(
+            ACTIVATIONS_DIR, _ACTIVATION_CONFS_DIR, fname
+        )
+        return read_annotation_file(activation_annotation_fpath)
 
     def _get_predominant_stem(self):
         """Get predominant stem if files exists.
@@ -274,6 +288,23 @@ class MultiTrack(object):
         return [
             track for track in self.raw_audio if track.stem_idx == stem_idx
         ]
+
+    def activation_conf_from_stem(self, stem_idx):
+        """Get all raw audio tracks that are children of a given stem.
+
+        Args:
+            stem_idx (int): stem index (eg. 2 for stem S02)
+
+        Returns:
+            activation_confidence (list): time and activation confidence
+
+        """
+
+        activations = []
+        for step in self.stem_activations:
+            activations.append([step[0], step[stem_idx]])
+
+        return activations
 
 
 class Track(object):
@@ -404,6 +435,7 @@ def read_annotation_file(fpath, num_cols=None):
         >>> melody_fpath = 'ArtistName_TrackTitle_MELODY1.txt'
         >>> pitch_fpath = 'my_tony_pitch_annotation.csv'
         >>> melody_annotation = read_annotation_file(melody_fpath)
+        >>> activation_annotation = read_annotation_file(actvation_fpath)
         >>> pitch_annotation = read_annotation_file(pitch_fpath, num_cols=2)
 
         The returned annotations can be directly converted to a numpy array,
@@ -428,6 +460,11 @@ def read_annotation_file(fpath, num_cols=None):
         with open(fpath) as f_handle:
             annotation = []
             linereader = csv.reader(f_handle)
+
+            # skip the headers for non csv files
+            if os.path.splitext(fpath)[1] == '.lab':
+                next(linereader, None)
+
             for line in linereader:
                 if num_cols:
                     line = line[:num_cols]

--- a/medleydb/multitrack.py
+++ b/medleydb/multitrack.py
@@ -290,7 +290,7 @@ class MultiTrack(object):
         ]
 
     def activation_conf_from_stem(self, stem_idx):
-        """Get all raw audio tracks that are children of a given stem.
+        """Get activation confidence from given stem.
 
         Args:
             stem_idx (int): stem index (eg. 2 for stem S02)

--- a/medleydb/sql/model.py
+++ b/medleydb/sql/model.py
@@ -174,6 +174,21 @@ class Track(DeclarativeBase):
         )
 
     @hybrid_property
+    def activations_data(self):
+        """ Get activation confidence annotation """
+        fname = medleydb.multitrack._ACTIVATION_CONFS_FMT % \
+            os.path.basename(self.track_id).split('.')[0]
+
+        activation_annotation_fpath = os.path.join(
+            medleydb.multitrack.ACTIVATIONS_DIR,
+            medleydb.multitrack._ACTIVATION_CONFS_DIR,
+            fname
+        )
+        return medleydb.multitrack.read_annotation_file(
+            activation_annotation_fpath
+        )
+
+    @hybrid_property
     def metadata_path(self):
         """ Get path of metadata file """
         return os.path.join(

--- a/medleydb/sql/model.py
+++ b/medleydb/sql/model.py
@@ -160,20 +160,6 @@ class Track(DeclarativeBase):
         return scipy.io.wavfile.read(self.audio_path)
 
     @hybrid_property
-    def pitch_data(self):
-        """ Get pitch annotation """
-        fname = medleydb.multitrack._PITCH_FMT % \
-            os.path.basename(self.metadata_filename).split('.')[0]
-        pitch_annotation_fpath = os.path.join(
-            medleydb.multitrack.PITCH_DIR,
-            fname
-        )
-        return medleydb.multitrack.read_annotation_file(
-            pitch_annotation_fpath,
-            num_cols=2
-        )
-
-    @hybrid_property
     def activations_data(self):
         """ Get activation confidence annotation """
         fname = medleydb.multitrack._ACTIVATION_CONFS_FMT % \

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ if __name__ == "__main__":
     setup(
         name='medleydb',
 
-        version='0.2.0',
+        version='0.2.1',
 
         description='Python module for the MedleyDB dataset',
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,9 @@ if __name__ == "__main__":
 
         extras_require={
             'sql': [
-                'SQLAlchemy'
+                'SQLAlchemy',
+                'scipy',
+                'numpy'
             ],
             'tests': [
                 'pytest',

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -33,7 +33,6 @@ def test_hybrid_properies(track):
     repr(track)
     track.audio_path
     track.audio_data
-    track.pitch_data
     track.activations_data
     track.base_dir
     track.track_id

--- a/tests/test_sql.py
+++ b/tests/test_sql.py
@@ -34,6 +34,7 @@ def test_hybrid_properies(track):
     track.audio_path
     track.audio_data
     track.pitch_data
+    track.activations_data
     track.base_dir
     track.track_id
     track.metadata_path


### PR DESCRIPTION
I have to admit, that this is not the most elegant solution, but it works for now, especially since this is an update to the already outdated 0.2.0 branch. 

A better way to add the activations would be to bind it to the stems. However, currently stems do not have a parent track_id relationship which means more changes need to be made. We can still do these changes when the 1.0/1.1 version is out.