### PR TITLE
Mix multitrack outputs

### DIFF
--- a/medleydb/data/Metadata/Adele_SomeoneLikeYou_METADATA.yaml
+++ b/medleydb/data/Metadata/Adele_SomeoneLikeYou_METADATA.yaml
@@ -25,14 +25,20 @@ stems:
   S02:
     component: melody
     filename: Adele_SomeoneLikeYou_STEM_02.wav
-    instrument: female singer
+    instrument: 
+      - female singer
+      - vocalists
     raw:
       R01:
         filename: Adele_SomeoneLikeYou_RAW_02_01.wav
-        instrument: female singer
+        instrument: 
+          - female singer
+          - vocalists
       R02:
         filename: Adele_SomeoneLikeYou_RAW_02_02.wav
-        instrument: female singer
+        instrument: 
+          - female singer
+          - vocalists
 title: Someone Like You
 version: 1.2
 website: ''

--- a/medleydb/mix.py
+++ b/medleydb/mix.py
@@ -36,6 +36,13 @@ def mix_multitrack(mtrack, output_path, stem_indices=None,
         List of tuples of (filepath, mixing_coefficient) pairs to additionally
         add to final mix.
 
+    Returns
+    -------
+    filepaths : list
+        List of filepaths used in the mix
+    weights : list
+        List of weights used to mix filepaths
+
     """
     filepaths, weights = _build_mix_args(
         mtrack, stem_indices, alternate_weights, alternate_files,
@@ -49,6 +56,8 @@ def mix_multitrack(mtrack, output_path, stem_indices=None,
         cbn.build(
             filepaths, output_path, 'mix', input_volumes=weights
         )
+
+    return filepaths, weights
 
 
 def _build_mix_args(mtrack, stem_indices, alternate_weights, alternate_files,
@@ -213,16 +222,12 @@ def mix_mono_stems(mtrack, output_path, include_percussion=False):
     stem_indices = []
     mono_indices = []
     for i in stems.keys():
-        print(stems[i].instrument)
-        print(stems[i].f0_type)
         mono = all([
             f0_type == 'm' for f0_type in mtrack.stems[i].f0_type
         ])
         unvoiced = all([
             f0_type == 'u' for f0_type in mtrack.stems[i].f0_type
         ])
-        print(mono)
-        print(unvoiced)
         if mono:
             stem_indices.append(i)
             mono_indices.append(i)

--- a/medleydb/version.py
+++ b/medleydb/version.py
@@ -2,4 +2,4 @@
 # -*- coding: utf-8 -*-
 """Version info"""
 
-version = "1.3.0"
+version = "1.3.1"

--- a/tests/test_mix.py
+++ b/tests/test_mix.py
@@ -22,53 +22,156 @@ class TestMixMultitrack(unittest.TestCase):
 
     def test_defaults(self):
         clean_output()
-        mix.mix_multitrack(
+        actual_fullpaths, actual_weights = mix.mix_multitrack(
             self.mtrack, OUTPUT_PATH
         )
+        
         self.assertTrue(os.path.exists(OUTPUT_PATH))
+
+        actual_basenames = [os.path.basename(f) for f in actual_fullpaths]
+        expected_basenames = [
+            'LizNelson_Rainfall_STEM_01.wav',
+            'LizNelson_Rainfall_STEM_02.wav',
+            'LizNelson_Rainfall_STEM_03.wav',
+            'LizNelson_Rainfall_STEM_04.wav',
+            'LizNelson_Rainfall_STEM_05.wav'
+        ]
+        expected_weights = [
+            0.9138225670999782,
+            0.88655832334783,
+            0.7820245646673145,
+            0.9709353677932278,
+            0.7734022629465723
+        ]
+        self.assertEqual(expected_basenames, actual_basenames)
+        self.assertEqual(expected_weights, actual_weights)
+
         clean_output()
 
     def test_less_stems(self):
         clean_output()
-        mix.mix_multitrack(
+        actual_fullpaths, actual_weights = mix.mix_multitrack(
             self.mtrack, OUTPUT_PATH, stem_indices=[2, 4]
         )
         self.assertTrue(os.path.exists(OUTPUT_PATH))
+
+        actual_basenames = [os.path.basename(f) for f in actual_fullpaths]
+        expected_basenames = [
+            'LizNelson_Rainfall_STEM_02.wav',
+            'LizNelson_Rainfall_STEM_04.wav'
+        ]
+        expected_weights = [
+            0.88655832334783,
+            0.9709353677932278
+        ]
+        self.assertEqual(expected_basenames, actual_basenames)
+        self.assertEqual(expected_weights, actual_weights)
+
         clean_output()
 
     def test_alt_weights(self):
         clean_output()
-        mix.mix_multitrack(
+        actual_fullpaths, actual_weights = mix.mix_multitrack(
             self.mtrack, OUTPUT_PATH, alternate_weights={2: 2.0, 4: 0.5}
         )
         self.assertTrue(os.path.exists(OUTPUT_PATH))
+
+        actual_basenames = [os.path.basename(f) for f in actual_fullpaths]
+        expected_basenames = [
+            'LizNelson_Rainfall_STEM_01.wav',
+            'LizNelson_Rainfall_STEM_02.wav',
+            'LizNelson_Rainfall_STEM_03.wav',
+            'LizNelson_Rainfall_STEM_04.wav',
+            'LizNelson_Rainfall_STEM_05.wav'
+        ]
+        expected_weights = [
+            0.9138225670999782,
+            2.0,
+            0.7820245646673145,
+            0.5,
+            0.7734022629465723
+        ]
+        self.assertEqual(expected_basenames, actual_basenames)
+        self.assertEqual(expected_weights, actual_weights)
+
         clean_output()
 
     def test_alt_files(self):
         clean_output()
-        mix.mix_multitrack(
+        actual_fullpaths, actual_weights = mix.mix_multitrack(
             self.mtrack, OUTPUT_PATH,
             alternate_files={1: self.mtrack.mix_path}
         )
         self.assertTrue(os.path.exists(OUTPUT_PATH))
+
+        actual_basenames = [os.path.basename(f) for f in actual_fullpaths]
+        expected_basenames = [
+            'LizNelson_Rainfall_MIX.wav',
+            'LizNelson_Rainfall_STEM_02.wav',
+            'LizNelson_Rainfall_STEM_03.wav',
+            'LizNelson_Rainfall_STEM_04.wav',
+            'LizNelson_Rainfall_STEM_05.wav'
+        ]
+        expected_weights = [
+            0.9138225670999782,
+            0.88655832334783,
+            0.7820245646673145,
+            0.9709353677932278,
+            0.7734022629465723
+        ]
+        self.assertEqual(expected_basenames, actual_basenames)
+        self.assertEqual(expected_weights, actual_weights)
+
         clean_output()
 
 
     def test_additional_files(self):
         clean_output()
-        mix.mix_multitrack(
+        actual_fullpaths, actual_weights = mix.mix_multitrack(
             self.mtrack, OUTPUT_PATH,
             additional_files=[(self.mtrack.mix_path, 2.1)]
         )
         self.assertTrue(os.path.exists(OUTPUT_PATH))
+
+        actual_basenames = [os.path.basename(f) for f in actual_fullpaths]
+        expected_basenames = [
+            'LizNelson_Rainfall_STEM_01.wav',
+            'LizNelson_Rainfall_STEM_02.wav',
+            'LizNelson_Rainfall_STEM_03.wav',
+            'LizNelson_Rainfall_STEM_04.wav',
+            'LizNelson_Rainfall_STEM_05.wav',
+            'LizNelson_Rainfall_MIX.wav'
+        ]
+        expected_weights = [
+            0.9138225670999782,
+            0.88655832334783,
+            0.7820245646673145,
+            0.9709353677932278,
+            0.7734022629465723,
+            2.1
+        ]
+        self.assertEqual(expected_basenames, actual_basenames)
+        self.assertEqual(expected_weights, actual_weights)
+
         clean_output()
 
     def test_one_stem_mix(self):
         clean_output()
-        mix.mix_multitrack(
+        actual_fullpaths, actual_weights = mix.mix_multitrack(
             self.mtrack, OUTPUT_PATH, stem_indices=[2]
         )
         self.assertTrue(os.path.exists(OUTPUT_PATH))
+
+        actual_basenames = [os.path.basename(f) for f in actual_fullpaths]
+        expected_basenames = [
+            'LizNelson_Rainfall_STEM_02.wav'
+        ]
+        expected_weights = [
+            0.88655832334783
+        ]
+        self.assertEqual(expected_basenames, actual_basenames)
+        self.assertEqual(expected_weights, actual_weights)
+
         clean_output()
 
 


### PR DESCRIPTION
Return outputs in the `mix.mix_multitrack` function.