### PR TITLE
Fix track title for Scotch Morris by Phoenix

### DIFF
--- a/medleydb/data/Metadata/Phoenix_ScotchMorris_METADATA.yaml
+++ b/medleydb/data/Metadata/Phoenix_ScotchMorris_METADATA.yaml
@@ -49,6 +49,6 @@ stems:
       R02:
         filename: Phoenix_ScotchMorris_RAW_04_02.wav
         instrument: Main System
-title: Lark On The Strand - Drummond Castle
+title: Scotch Morris
 version: 1.2
 website: null


### PR DESCRIPTION
This mislabeling is also present in the example dataset hosted at https://zenodo.org/record/1438309/files/MedleyDB_Sample.tar.gz.